### PR TITLE
feat: add audio effects and optimize timing delays

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,8 @@ int main() {
 
     State state(window);
 
+    Audio::instance();
+
     std::thread thread([&]() {
         while (window.isOpen()) {
             state.update();

--- a/src/player/ai_player.hpp
+++ b/src/player/ai_player.hpp
@@ -5,6 +5,9 @@
 
 #include "player.hpp"
 
+constexpr std::chrono::duration THINKING_DELAY =
+    std::chrono::milliseconds(1500);
+
 /// An AI-controlled player for the UNO game.
 class AiPlayer: public Player {
   public:
@@ -16,11 +19,10 @@ class AiPlayer: public Player {
             if ((*it)->can_play_on(discard_pile.peek_top())) {
                 auto card = std::move(*it);
                 cards_.erase(it);
-                std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+                std::this_thread::sleep_for(THINKING_DELAY);
                 return card;
             }
         }
-        std::this_thread::sleep_for(std::chrono::milliseconds(500));
         return std::nullopt;
     }
 

--- a/src/player/local_player.hpp
+++ b/src/player/local_player.hpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <mutex>
-#include <thread>
 
 #include "../button.hpp"
 #include "player.hpp"
@@ -39,7 +38,6 @@ class LocalPlayer: public Player {
     optional<unique_ptr<Card>>
     play_card(const DiscardPile& discard_pile) override {
         if (!has_playable_card(discard_pile)) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(500));
             return std::nullopt;
         }
         while (!selected_card_index_.has_value())


### PR DESCRIPTION
Close: #10.

- Add audio effects for placing and sliding cards
- Introduce global constants for timing delays
- Refactor AI player thinking delay
- Adjust draw card delay for better game flow
- Set initial player position to South