### PR TITLE
feat(player): update picker colors to fit UNO cards

### DIFF
--- a/src/player/local_player.hpp
+++ b/src/player/local_player.hpp
@@ -6,6 +6,15 @@
 #include "../button.hpp"
 #include "player.hpp"
 
+constexpr Color PICKER_COLORS[] =
+    {Color::Red, Color::Green, Color::Blue, Color::Yellow};
+constexpr sf::Color PICKER_SFML_COLORS[] = {
+    sf::Color(207, 87, 60),
+    sf::Color(70, 130, 50),
+    sf::Color(79, 143, 186),
+    sf::Color(222, 158, 65),
+};
+
 class LocalPlayer: public Player {
   public:
     LocalPlayer(

--- a/src/player/player.hpp
+++ b/src/player/player.hpp
@@ -11,10 +11,6 @@ using std::unique_ptr;
 using std::vector;
 
 constexpr float MAX_SPACING = 70.0f;
-constexpr Color PICKER_COLORS[] =
-    {Color::Red, Color::Green, Color::Blue, Color::Yellow};
-constexpr sf::Color PICKER_SFML_COLORS[] =
-    {sf::Color::Red, sf::Color::Green, sf::Color::Blue, sf::Color::Yellow};
 
 enum class Position : uint8_t { North, East, South, West };
 


### PR DESCRIPTION
Close: #8.

- Move PICKER_COLORS and PICKER_SFML_COLORS from player.hpp to local_player.hpp
- Update color values to fit UNO cards